### PR TITLE
Loop the grid when you reach the end

### DIFF
--- a/jquery.infinitedrag.js
+++ b/jquery.infinitedrag.js
@@ -61,6 +61,7 @@
 			start_row: 0,
 			range_col: [-1000000, 1000000],
 			range_row: [-1000000, 1000000],
+			loop_ranges: false,
 			margin: 0,
 			cleaning_enabled: true,
 			remove_buffer: 10,
@@ -88,8 +89,22 @@
 
 		function create_tile(i, j) {
 			if (i < _to.range_col[0] || _to.range_col[1] < i) {
-				return;
-			} else if (j < _to.range_row[0] || _to.range_row[1] < j) {
+				if(_to.loop_ranges) {
+					if(i < _to.range_col[0]) i = _to.range_col[1];
+					if(_to.range_col[1] < i) i = _to.range_col[0];
+				}
+				else {
+					return;
+				}
+			}
+			if (j < _to.range_row[0] || _to.range_row[1] < j) {
+				if(_to.loop_ranges) {
+					if(j < _to.range_row[0]) j = _to.range_row[1];
+					if(_to.range_row[1] < j) j = _to.range_row[0];
+				}
+				else {
+					return;
+				}
 				return;
 			}
 
@@ -244,7 +259,7 @@
 			if (_to.cleaning_enabled) {
 				return;
 			}
-			
+
 			// Finds tiles which can be seen based on window width & height
 			var maxLeft = (left + viewport_cols) + 1,
 				maxTop = (top + viewport_rows);

--- a/jquery.infinitedrag.js
+++ b/jquery.infinitedrag.js
@@ -88,6 +88,8 @@
 		// Creates the tile at (i, j).
 
 		function create_tile(i, j) {
+			var i_requested = i;
+			var j_requested = j;
 			if (i < _to.range_col[0] || _to.range_col[1] < i) {
 				if(_to.loop_ranges) {
 					if(i < _to.range_col[0]) i = _to.range_col[1];
@@ -121,7 +123,7 @@
 				col: i,
 				row: j
 			});
-			_setTileStyle($new_tile, i, j);
+			_setTileStyle($new_tile, i_requested, j_requested);
 
 			if (_to.on_aggregate) {
 				aggregator_data.push({

--- a/jquery.infinitedrag.js
+++ b/jquery.infinitedrag.js
@@ -105,7 +105,6 @@
 				else {
 					return;
 				}
-				return;
 			}
 
 


### PR DESCRIPTION
A quick attempt at [#4 A feature to wrap the grid at edges](https://github.com/Sleavely/jquery-infinite-drag/issues/4)

Some notes:
- `cleaning_enabled` must be enabled for this to work, because if there is already an active tile with the specified coordinates `create_tile()` will not be called.
- Untested code :speak_no_evil: 
